### PR TITLE
Configurable success/failed payment redirect routes for Monetico

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -63,6 +63,9 @@ services:
 
     # Status HTTP Response Provider
     LakeDynamics\SyliusMoneticoPlugin\Provider\StatusHttpResponseProvider:
+        arguments:
+            $failedPaymentRedirectRoute: '%lake_dynamics_sylius_monetico.failed_payment_redirect_route%'
+            $successPaymentRedirectRoute: '%lake_dynamics_sylius_monetico.success_payment_redirect_route%'
         tags:
             - { name: lake_dynamics.sylius_monetico.provider.http_response.monetico, action: !php/const Sylius\Component\Payment\Model\PaymentRequestInterface::ACTION_STATUS }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -17,6 +17,19 @@ final class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('lake_dynamics_sylius_monetico');
         $rootNode = $treeBuilder->getRootNode();
 
+        $rootNode
+            ->children()
+                ->scalarNode('failed_payment_redirect_route')
+                    ->cannotBeEmpty()
+                    ->defaultValue('sylius_shop_order_show')
+                ->end()
+                ->scalarNode('success_payment_redirect_route')
+                    ->cannotBeEmpty()
+                    ->defaultValue('sylius_shop_order_thank_you')
+                ->end()
+            ->end()
+        ;
+
         return $treeBuilder;
     }
 }

--- a/src/DependencyInjection/LakeDynamicsSyliusMoneticoExtension.php
+++ b/src/DependencyInjection/LakeDynamicsSyliusMoneticoExtension.php
@@ -18,6 +18,19 @@ final class LakeDynamicsSyliusMoneticoExtension extends AbstractResourceExtensio
     /** @psalm-suppress UnusedVariable */
     public function load(array $configs, ContainerBuilder $container): void
     {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $container->setParameter(
+            'lake_dynamics_sylius_monetico.failed_payment_redirect_route',
+            $config['failed_payment_redirect_route'],
+        );
+
+        $container->setParameter(
+            'lake_dynamics_sylius_monetico.success_payment_redirect_route',
+            $config['success_payment_redirect_route'],
+        );
+
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../../config'));
 
         $loader->load('services.xml');

--- a/src/Provider/StatusHttpResponseProvider.php
+++ b/src/Provider/StatusHttpResponseProvider.php
@@ -16,6 +16,8 @@ final readonly class StatusHttpResponseProvider implements HttpResponseProviderI
 {
     public function __construct(
         private UrlGeneratorInterface $urlGenerator,
+        private string $failedPaymentRedirectRoute,
+        private string $successPaymentRedirectRoute,
     ) {
     }
 
@@ -32,15 +34,35 @@ final readonly class StatusHttpResponseProvider implements HttpResponseProviderI
             throw new \RuntimeException('PaymentRequest has no valid payment');
         }
 
-        $order = $payment->getOrder();
-        if (null === $order) {
-            throw new \RuntimeException('Payment has no order');
+        $isSuccessful = in_array(
+            $payment->getState(),
+            [PaymentInterface::STATE_COMPLETED, PaymentInterface::STATE_AUTHORIZED],
+            true,
+        );
+
+        if ($isSuccessful) {
+            $url = $this->urlGenerator->generate(
+                $this->successPaymentRedirectRoute,
+                [],
+                UrlGeneratorInterface::ABSOLUTE_URL,
+            );
+
+            return new RedirectResponse($url);
         }
 
-        // Redirect to the order thank you page
+        $routeParameters = [];
+        if ('sylius_shop_order_show' === $this->failedPaymentRedirectRoute) {
+            $order = $payment->getOrder();
+            if (null === $order) {
+                throw new \RuntimeException('Payment has no order');
+            }
+
+            $routeParameters['tokenValue'] = $order->getTokenValue();
+        }
+
         $url = $this->urlGenerator->generate(
-            'sylius_shop_order_thank_you',
-            [],
+            $this->failedPaymentRedirectRoute,
+            $routeParameters,
             UrlGeneratorInterface::ABSOLUTE_URL,
         );
 

--- a/tests/Unit/Provider/StatusHttpResponseProviderTest.php
+++ b/tests/Unit/Provider/StatusHttpResponseProviderTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\LakeDynamics\SyliusMoneticoPlugin\Unit\Provider;
+
+use LakeDynamics\SyliusMoneticoPlugin\Provider\StatusHttpResponseProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Payment\Model\PaymentInterface as BasePaymentInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class StatusHttpResponseProviderTest extends TestCase
+{
+    private UrlGeneratorInterface&MockObject $urlGenerator;
+
+    private StatusHttpResponseProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $this->provider = new StatusHttpResponseProvider(
+            $this->urlGenerator,
+            'sylius_shop_order_show',
+            'sylius_shop_order_thank_you',
+        );
+    }
+
+    public function testItSupportsStatusAction(): void
+    {
+        $requestConfiguration = $this->createMock(RequestConfiguration::class);
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getAction')->willReturn(PaymentRequestInterface::ACTION_STATUS);
+
+        self::assertTrue($this->provider->supports($requestConfiguration, $paymentRequest));
+    }
+
+    public function testItDoesNotSupportNonStatusAction(): void
+    {
+        $requestConfiguration = $this->createMock(RequestConfiguration::class);
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getAction')->willReturn(PaymentRequestInterface::ACTION_CAPTURE);
+
+        self::assertFalse($this->provider->supports($requestConfiguration, $paymentRequest));
+    }
+
+    public function testItRedirectsSuccessfulPaymentToSuccessRoute(): void
+    {
+        $requestConfiguration = $this->createMock(RequestConfiguration::class);
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getState')->willReturn(PaymentInterface::STATE_COMPLETED);
+
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+
+        $this->urlGenerator
+            ->expects(self::once())
+            ->method('generate')
+            ->with('sylius_shop_order_thank_you', [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://example.com/thank-you');
+
+        $response = $this->provider->getResponse($requestConfiguration, $paymentRequest);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        /** @var RedirectResponse $response */
+        self::assertSame(302, $response->getStatusCode());
+        self::assertSame('https://example.com/thank-you', $response->getTargetUrl());
+    }
+
+    public function testItRedirectsFailedPaymentToFailedRouteWithTokenValueForOrderShowRoute(): void
+    {
+        $requestConfiguration = $this->createMock(RequestConfiguration::class);
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getTokenValue')->willReturn('order-token');
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getState')->willReturn(PaymentInterface::STATE_FAILED);
+        $payment->method('getOrder')->willReturn($order);
+
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+
+        $this->urlGenerator
+            ->expects(self::once())
+            ->method('generate')
+            ->with(
+                'sylius_shop_order_show',
+                ['tokenValue' => 'order-token'],
+                UrlGeneratorInterface::ABSOLUTE_URL,
+            )
+            ->willReturn('https://example.com/order/show');
+
+        $response = $this->provider->getResponse($requestConfiguration, $paymentRequest);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        /** @var RedirectResponse $response */
+        self::assertSame('https://example.com/order/show', $response->getTargetUrl());
+    }
+
+    public function testItRedirectsFailedPaymentToCustomRouteWithoutTokenValue(): void
+    {
+        $provider = new StatusHttpResponseProvider(
+            $this->urlGenerator,
+            'app_payment_failed',
+            'sylius_shop_order_thank_you',
+        );
+
+        $requestConfiguration = $this->createMock(RequestConfiguration::class);
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getState')->willReturn(PaymentInterface::STATE_CANCELLED);
+
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+
+        $this->urlGenerator
+            ->expects(self::once())
+            ->method('generate')
+            ->with('app_payment_failed', [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://example.com/payment/failed');
+
+        $response = $provider->getResponse($requestConfiguration, $paymentRequest);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        /** @var RedirectResponse $response */
+        self::assertSame('https://example.com/payment/failed', $response->getTargetUrl());
+    }
+
+    public function testItThrowsWhenPaymentRequestHasNoValidPayment(): void
+    {
+        $requestConfiguration = $this->createMock(RequestConfiguration::class);
+        $payment = $this->createMock(BasePaymentInterface::class);
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('PaymentRequest has no valid payment');
+
+        $this->provider->getResponse($requestConfiguration, $paymentRequest);
+    }
+
+    public function testItThrowsWhenPaymentHasNoOrderForOrderShowRoute(): void
+    {
+        $requestConfiguration = $this->createMock(RequestConfiguration::class);
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getState')->willReturn(PaymentInterface::STATE_FAILED);
+        $payment->method('getOrder')->willReturn(null);
+
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Payment has no order');
+
+        $this->provider->getResponse($requestConfiguration, $paymentRequest);
+    }
+}


### PR DESCRIPTION
## Context

Make Monetico redirect behavior configurable so failed/cancelled payments go to a configurable route (default: order recap), while successful payments still go to the thank-you page.

## Changes

- **Configuration**: Added two scalar nodes under `lake_dynamics_sylius_monetico`:
  - `failed_payment_redirect_route` (default: `sylius_shop_order_show`)
  - `success_payment_redirect_route` (default: `sylius_shop_order_thank_you`)

- **Extension**: Expose both values as container parameters for injection into the status provider.

- **StatusHttpResponseProvider**: Redirect conditionally by payment state:
  - `completed` or `authorized` → success route
  - Otherwise → failed route (with `tokenValue` when using `sylius_shop_order_show`)

- **Tests**: Added unit tests for success/failure routing, custom routes, and error cases.

## Tests

```
PHPUnit 10.5.58
OK (14 tests, 32 assertions)
```