### PR TITLE
Fix undefined variable $randomChars in MoneticoService::generateReference()

### DIFF
--- a/src/Service/MoneticoService.php
+++ b/src/Service/MoneticoService.php
@@ -174,6 +174,7 @@ final class MoneticoService
         $timestamp = base_convert((string) time(), 10, 36);
         $length = 12 - strlen($id) - strlen($timestamp);
         $chars = '0123456789abcdefghijklmnopqrstuvwxyz';
+        $randomChars = '';
         for ($i = 0; $i < $length; $i++) {
             $randomChars .= $chars[random_int(0, strlen($chars) - 1)];
         }


### PR DESCRIPTION
## Description

Fixes #2

Initialize `$randomChars` before the loop in `MoneticoService::generateReference()` to fix the PHP 8.2+ undefined variable warning when paying through the Monetico payment gateway.

The `.=` operator concatenates to an existing value, but `$randomChars` was never declared before the loop, causing an "Undefined variable" warning.

## Changes
- Added `$randomChars = '';` before the for loop in `generateReference()`

## Testing
- All PHPUnit tests pass (14 tests, 32 assertions)